### PR TITLE
need a .trufflehog.txt for static analysis action

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,6 +1,11 @@
 name: Static analysis
 
-on: push
+on:
+  push:
+  pull_request:
+    types:
+      - opened
+      - synchronize
 
 jobs:
   call-flake8-workflow:


### PR DESCRIPTION
the `static-analysis.yml` action needs a `.trufflehog.txt` file at the repository root, but it *can* be empty. This adds that.

Also adds a PR trigger to the static analysis so it runs on fork PRs as well.